### PR TITLE
Add support for seperate consumption/production entities and a few layout and copy tweaks.

### DIFF
--- a/config-entity-functions.js
+++ b/config-entity-functions.js
@@ -3,6 +3,8 @@ import * as constants from "./constants.js";
 export function buildConfig(config) {
   let new_config = constants.base_config;
 
+  new_config.title = config.title;
+
   // Check inverter count
   let inverter_count = parseInt(config.inverter_count);
   if (isNaN(inverter_count) || inverter_count <= 0) {

--- a/config-entity-functions.js
+++ b/config-entity-functions.js
@@ -229,24 +229,6 @@ export function getEntitiesNumState(config, hass, config_entity, index, is_int =
   return Math.round(value * 100) / 100;
 }
 
-export function getEntitiesNumState(config, hass, config_entity, index, is_int = true, is_avg = false) {
-  let value = 0;
-  if (index == -1) {
-    for (let i = 0; i < config.inverter_count; i++) {
-      value += parseFloat(getEntitiesState(config, hass, config_entity, i));
-    }
-    if (is_avg) {
-      value = value / config.inverter_count;
-    }
-  } else {
-    value = parseFloat(getEntitiesState(config, hass, config_entity, index));
-  }
-  if (is_int) {
-    return parseInt(value);
-  }
-  return Math.round(value * 100) / 100;
-}
-
 export function getEntitiesAttribute(config, hass, config_entity, attribute_name, index) {
   const entity = getEntity(config, hass, config_entity, index);
 

--- a/config-entity-functions.js
+++ b/config-entity-functions.js
@@ -164,7 +164,7 @@ export function getEntity(config, hass, config_entity, index) {
     }
   }
 
-  if (typeof entityConfig.consumption === "string" && typeof entityConfig.production === "string") {
+  if (entityConfig && typeof entityConfig.consumption === "string" && typeof entityConfig.production === "string") {
     const consumptionValue = parseInt(getEntitiesStateValue(hass.states[entityConfig.consumption]));
     const productionValue = parseInt(getEntitiesStateValue(hass.states[entityConfig.production]));
 
@@ -188,7 +188,7 @@ export function getEntitiesState(config, hass, config_entity, index) {
   let value = getEntitiesStateValue(entity);
 
   const entityConfig = config[config_entity].entities[index];
-  if (typeof entityConfig !== "string" && typeof entityConfig.consumption === "string" && typeof entityConfig.production === "string") {
+  if (entityConfig && typeof entityConfig !== "string" && typeof entityConfig.consumption === "string" && typeof entityConfig.production === "string") {
     const consumptionValue = parseInt(getEntitiesStateValue(hass.states[entityConfig.consumption]));
     const productionValue = parseInt(getEntitiesStateValue(hass.states[entityConfig.production]));
 
@@ -201,7 +201,7 @@ export function getEntitiesState(config, hass, config_entity, index) {
 }
 
 function getEntitiesStateValue(entity) {
-  if (entity.state) {
+  if (entity && entity.state) {
     if (entity.state === "unavailable" || entity.state === "unknown") {
       return "-";
     } else {

--- a/constants.js
+++ b/constants.js
@@ -70,7 +70,7 @@ export const base_config = {
 };
 
 export function getBatteryImage(battery_soc) {
-  if (battery_soc == 100) {
+  if (battery_soc >= 99) {
     return getBase64Data("battery-5");
   } else if (battery_soc >= 80) {
     return getBase64Data("battery-4");

--- a/constants.js
+++ b/constants.js
@@ -1,5 +1,6 @@
 export const base_config = {
   inverter_count: null,
+  title: null,
   parallel: {
     average_voltage: false,
     parallel_first: true,

--- a/html-functions.js
+++ b/html-functions.js
@@ -28,6 +28,36 @@ export function generateStyles(config) {
     max-width: 100%;
     max-height: 100%;
   }
+
+  #solar-info {
+    grid-column-start: span 2;
+  }
+  #solar-info p {
+    display: block;
+  }
+
+  #battery-image {
+    display: flex;
+  }
+
+  #battery-image img {
+    height: 50px;
+  }
+
+  #battery-charge-info {
+    align-items: flex-end;
+    padding-bottom: 0.5em;
+  }
+
+  #battery-soc-info {
+    padding-top: 0.5em;
+  }
+
+  #home-info {
+    align-items: center;
+    padding-left: 0.5em;
+    grid-column-start: span 2;
+  }
   
   /* CELLS */
   .cell {
@@ -53,8 +83,7 @@ export function generateStyles(config) {
     text-align: right;
     } */
   .header-text {
-    font-size: min(4vw, 1.17em);
-    font-weight: bold;
+    font-size: min(4vw, 1em);
     line-height: 1;
     margin: 0;
     padding-left: 3px;
@@ -64,6 +93,7 @@ export function generateStyles(config) {
   }
   .sub-text {
     font-size: min(2.5vw, 0.95em);
+    color: var(--secondary-text-color);
     line-height: 1;
     margin: 0;
     padding-left: 3px;
@@ -79,7 +109,7 @@ export function generateStyles(config) {
     align-items: center;
     text-align: center;
     justify-content: center;
-    width: auto;
+    width: 70%;
     object-fit: contain;
     position: relative;
   }
@@ -279,7 +309,6 @@ export function generateGrid(config) {
     cells += `<div id="solar-image" class="cell image-cell"><img src="${constants.getBase64Data("solar")}"></div>`; // Solar image
     cells += `<div id="solar-info" class="cell text-cell"></div>`; // Solar info
     cells += `<div class="cell"></div>`;
-    cells += `<div class="cell"></div>`;
     // Row 1
     cells += `<div id="battery-charge-info" class="cell text-cell"></div>`; // Battery charge/discharge info
     cells += `<div class="cell"></div>`;
@@ -316,8 +345,8 @@ export function generateGrid(config) {
   if (config.energy_allocations.is_used) {
     // Power Allocations
     cells += `<div class="cell">${refresh_button_left}</div>`;
-    cells += `<div id="home-info" class="cell text-cell"></div>`; // Home info
     cells += `<div id="home-image" class="cell image-cell"><img src="${constants.getBase64Data("home-normal")}"></div>`; // Home image
+    cells += `<div id="home-info" class="cell text-cell"></div>`; // Home info
     cells += `<div id="power-allocation-arrows" class="cell arrow-cell"></div>`; // Power allocation arrows
     cells += `<div id="power-allocation-image" class="cell image-cell"><img src="${constants.getBase64Data(
       "home-normal"
@@ -325,10 +354,9 @@ export function generateGrid(config) {
     cells += `<div id="power-allocation-info" class="cell text-cell"></div>`; // Power allocation info
   } else {
     cells += `<div class="cell">${refresh_button_left}</div>`;
-    cells += `<div id="home-info" class="cell text-cell"></div>`; // Home info
+    cells += `<div class="cell"></div>`;
     cells += `<div id="home-image" class="cell image-cell"><img src="${constants.getBase64Data("home-normal")}"></div>`; // Home image
-    cells += `<div class="cell"></div>`;
-    cells += `<div class="cell"></div>`;
+    cells += `<div id="home-info" class="cell text-cell"></div>`; // Home info
     cells += `<div class="cell"></div>`;
   }
 

--- a/html-functions.js
+++ b/html-functions.js
@@ -89,6 +89,9 @@ export function generateStyles(config) {
   }
   
   /* ARROWS */
+  #grid-arrows {
+    grid-column-start: span 2;
+  }
   .arrow-cell {
     margin: auto;
     display: flex;
@@ -99,6 +102,11 @@ export function generateStyles(config) {
     width: auto;
     object-fit: contain;
     position: relative;
+    margin: 10px;
+  }
+  .arrow-cell img {
+    height: 16px;
+    width: 11px
   }
   .arrows-left {
     transform: rotate(0deg);
@@ -107,27 +115,27 @@ export function generateStyles(config) {
     transform: rotate(90deg);
   }
   .arrows-right {
-    transform: rotate(180deg);
+    transform: rotate(180deg) translateY(4px);
   }
   .arrows-down {
-    transform: rotate(-90deg);
+    transform: rotate(-90deg) translateY(4px);
   }
   .arrows-none {
     opacity: 0;
   }
   
   /* ARROW ANIMATIONS*/
-  .arrow-1 img {
-    animation: arrow-animation-1 1.5s infinite;
+  .arrow-1 img, .arrow-5 img {
+    animation: arrow-animation-1 1.25s infinite;
   }
-  .arrow-2 img {
-    animation: arrow-animation-2 1.5s infinite;
+  .arrow-2 img, .arrow-6 img {
+    animation: arrow-animation-2 1.25s infinite;
   }
-  .arrow-3 img {
-    animation: arrow-animation-3 1.5s infinite;
+  .arrow-3 img, .arrow-7 img {
+    animation: arrow-animation-3 1.25s infinite;
   }
-  .arrow-4 img {
-    animation: arrow-animation-4 1.5s infinite;
+  .arrow-4 img, .arrow-8 img {
+    animation: arrow-animation-4 1.25s infinite;
   }
   @keyframes arrow-animation-1 {
     0%,
@@ -293,8 +301,7 @@ export function generateGrid(config) {
   cells += `<div id="battery-image" class="cell image-cell"><img src="${constants.getBase64Data("battery-0")}"></div>`; // Battery image
   cells += `<div id="battery-arrows" class="cell arrow-cell"></div>`; // Battery arrows
   cells += `<div id="inverter-image" class="cell image-cell"><img src="${constants.getBase64Data("inverter")}"></div>`; // Inverter image
-  cells += `<div id="grid-arrows-1" class="cell arrow-cell"></div>`; // Grid arrows 1
-  cells += `<div id="grid-arrows-2" class="cell arrow-cell"></div>`; // Grid arrows 2
+  cells += `<div id="grid-arrows" class="cell arrow-cell"></div>`; // Grid arrows
   cells += `<div id="grid-image" class="cell image-cell"><img src="${constants.getBase64Data("grid")}"></div>`; // Grid image
 
   // Row 3
@@ -343,9 +350,9 @@ export function generateDateTime(config) {
   return date_time_info;
 }
 
-export function generateArrows() {
+export function generateArrows(num) {
   var inner_html = ``;
-  for (let i = 1; i < 5; i++) {
+  for (let i = 1; i <= num; i++) {
     inner_html += `<div class="arrow-${i}"><img src="${constants.getBase64Data("arrow")}"></div>`;
   }
   return inner_html;

--- a/html-functions.js
+++ b/html-functions.js
@@ -197,14 +197,12 @@ export function generateStyles(config) {
 }
 
 export const card_base = `
-  <ha-card>
-    <div id="taskbar-grid" class="status-grid">
-    </div>
-    <div id="card-grid" class="diagram-grid">
-    </div>
-    <div id="datetime-info" class="update-time">
-    </div>
-  </ha-card>
+  <div id="taskbar-grid" class="status-grid">
+  </div>
+  <div id="card-grid" class="diagram-grid">
+  </div>
+  <div id="datetime-info" class="update-time">
+  </div>
 `;
 
 export function generateStatus(config) {

--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -284,7 +284,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       const arrow_direction = pv_power > 0 ? "arrows-down" : "arrows-none";
       if (solar_arrow_element.className != `cell arrow-cell ${arrow_direction}`) {
         solar_arrow_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
-        solar_arrow_element.innerHTML = hf.generateArrows();
+        solar_arrow_element.innerHTML = hf.generateArrows(4);
       }
       // Info
       solar_info_element.innerHTML = `
@@ -311,7 +311,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       if (battery_arrow_element) {
         if (battery_arrow_element.className != `cell arrow-cell ${arrow_direction}`) {
           battery_arrow_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
-          battery_arrow_element.innerHTML = hf.generateArrows();
+          battery_arrow_element.innerHTML = hf.generateArrows(4);
         }
       }
       // Charge info
@@ -351,16 +351,13 @@ class LuxPowerDistributionCard extends HTMLElement {
 
   updateGrid(index) {
     // Arrow
-    const grid_arrow_1_element = this.card.querySelector("#grid-arrows-1");
-    const grid_arrow_2_element = this.card.querySelector("#grid-arrows-2");
-    let grid_flow = cef.getEntitiesNumState(this.config, this._hass, "grid_flow", index);
-    if (grid_arrow_1_element && grid_arrow_2_element) {
+    const grid_arrow_element = this.card.querySelector("#grid-arrows");
+    if (grid_arrow_element) {
+      const grid_flow = cef.getEntitiesNumState(this.config, this._hass, "grid_flow", index);
       const arrow_direction = grid_flow < 0 ? "arrows-left" : grid_flow > 0 ? "arrows-right" : "arrows-none";
-      if (grid_arrow_1_element.className != `cell arrow-cell ${arrow_direction}`) {
-        grid_arrow_1_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
-        grid_arrow_2_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
-        grid_arrow_1_element.innerHTML = hf.generateArrows();
-        grid_arrow_2_element.innerHTML = hf.generateArrows();
+      if (grid_arrow_element.className != `cell arrow-cell ${arrow_direction}`) {
+        grid_arrow_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
+        grid_arrow_element.innerHTML = hf.generateArrows(8);
       }
     }
     var grid_emoji = ``;
@@ -417,7 +414,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       const arrow_direction = home_consumption > 0 || backup_power > 0 ? "arrows-down" : "arrows-none";
       if (home_arrow_element.className != `cell arrow-cell ${arrow_direction}`) {
         home_arrow_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);
-        home_arrow_element.innerHTML = hf.generateArrows();
+        home_arrow_element.innerHTML = hf.generateArrows(4);
       }
     }
     // Info
@@ -528,7 +525,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       if (power_allocation_arrow_element) {
         if (power_allocation_arrow_element.className != `cell arrow-cell arrows-right`) {
           power_allocation_arrow_element.setAttribute("class", `cell arrow-cell arrows-right`);
-          power_allocation_arrow_element.innerHTML = hf.generateArrows();
+          power_allocation_arrow_element.innerHTML = hf.generateArrows(4);
         }
 
         const power_allocation_info_element = this.card.querySelector("#power-allocation-info");

--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -272,7 +272,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       msg = `Status: ${msg}`;
     }
     const status_element = this.card.querySelector("#status-cell");
-    if (status_element) {
+    if (this.config.status_codes.is_used && status_element) {
       status_element.innerHTML = msg;
     }
   }
@@ -354,8 +354,8 @@ class LuxPowerDistributionCard extends HTMLElement {
   updateGrid(index) {
     // Arrow
     const grid_arrow_element = this.card.querySelector("#grid-arrows");
+    const grid_flow = cef.getEntitiesNumState(this.config, this._hass, "grid_flow", index);
     if (grid_arrow_element) {
-      const grid_flow = cef.getEntitiesNumState(this.config, this._hass, "grid_flow", index);
       const arrow_direction = grid_flow < 0 ? "arrows-left" : grid_flow > 0 ? "arrows-right" : "arrows-none";
       if (grid_arrow_element.className != `cell arrow-cell ${arrow_direction}`) {
         grid_arrow_element.setAttribute("class", `cell arrow-cell ${arrow_direction}`);

--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -290,7 +290,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       solar_info_element.innerHTML = `
         <div>
           <p class="header-text">${this.formatPowerStates("pv_power", pv_power, index)}</p>
-          <p class="sub-text">${pv_power > 0 ? "Solar Import" : ""}</p>
+          <p class="sub-text">${pv_power > 0 ? "PV Power" : ""}</p>
         </div>
       `;
     }
@@ -320,7 +320,7 @@ class LuxPowerDistributionCard extends HTMLElement {
         <div>
           <p class="header-text">${this.formatPowerStates("battery_flow", battery_flow, index)}</p>
           <p class="sub-text">${
-            battery_flow > 0 ? "Battery Charging" : battery_flow < 0 ? "Battery Discharging" : "Idle"
+            battery_flow > 0 ? "Charging" : battery_flow < 0 ? "Discharging" : "Idle"
           }</p>
         </div>
       `;
@@ -342,8 +342,8 @@ class LuxPowerDistributionCard extends HTMLElement {
     if (battery_soc_info_element) {
       battery_soc_info_element.innerHTML = `
         <div>
-          <p class="header-text">${battery_soc}%</p>
           <p class="header-text">${battery_voltage}</p>
+          <p class="header-text">${battery_soc}%</p>
         </div>
     `;
     }
@@ -420,7 +420,7 @@ class LuxPowerDistributionCard extends HTMLElement {
     // Info
     const home_info_element = this.card.querySelector("#home-info");
     if (home_info_element) {
-      var sub_text = "Home Usage";
+      var sub_text = "Consumption";
       var value = this.formatPowerStates("home_consumption", home_consumption, index);
 
       if (this.config.backup_power.is_used && home_consumption == 0 && backup_power > 0) {
@@ -430,8 +430,8 @@ class LuxPowerDistributionCard extends HTMLElement {
 
       home_info_element.innerHTML = `
         <div>
-          <p class="sub-text">${sub_text}</p>
           <p class="header-text">${value}</p>
+          <p class="sub-text">${sub_text}</p>
         </div>
       `;
     }

--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -24,8 +24,6 @@ class LuxPowerDistributionCard extends HTMLElement {
       this.old_config = this.config;
       this.createCard();
     }
-
-    // console.log(this.config);
   }
 
   createCard() {
@@ -34,11 +32,17 @@ class LuxPowerDistributionCard extends HTMLElement {
     }
 
     this.card = document.createElement("ha-card");
-    if (this.config.header) {
-      this.card.header = this.config.header;
+    this.card.classList.add('type-custom-lux-power-distribution-card');
+
+    if (this.config.title) {
+      const header = document.createElement("h1");
+      header.classList.add('card-header');
+      header.appendChild(document.createTextNode(this.config.title));
+      this.card.appendChild(header);
     }
 
     const content = document.createElement("div");
+    content.classList.add('card-content')
     this.card.appendChild(content);
 
     this.styles = document.createElement("style");

--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -9,7 +9,7 @@ class LuxPowerDistributionCard extends HTMLElement {
     if (!this.card) {
       this.createCard();
       this.bindRefresh(this.card, this._hass, this.config);
-      this.bindHistoryGraph(this.card, this.config);
+      this.bindHistoryGraph(this.card, this._hass, this.config);
     }
 
     this.updateCard();
@@ -170,7 +170,7 @@ class LuxPowerDistributionCard extends HTMLElement {
     }
   }
 
-  bindHistoryGraph(card, config) {
+  bindHistoryGraph(card, hass, config) {
     const history_map = {
       "#solar-image": "pv_power",
       "#battery-image": "battery_soc",
@@ -195,13 +195,15 @@ class LuxPowerDistributionCard extends HTMLElement {
               }
             }
 
+            const entityId = cef.getEntity(config, hass, value, index).entity_id;
+
             const event = new Event("hass-more-info", {
               bubbles: true,
               cancelable: false,
               composed: true,
             });
             event.detail = {
-              entityId: config[value].entities[index],
+              entityId,
             };
             card.dispatchEvent(event);
             return event;


### PR DESCRIPTION
Thank you for creating this wonderful card.
I have made a few changes which I'm using myself, I wondered if any of these may be useful to the main branch.

* Added support for separate consumption and production entities for flows. Adds flexibility and simplifies use by users of lxp-bridge (maintains support for multiple inverters)
* Fixed the header not settable, renamed to title for consistency with other HA cards.
* Shows full battery image if SOC >= 99 (Some inverters never return SOC at 100%)
* Reworked the arrows and adjust the css grid to help with consistent spacing and sizing
* A few label and icon adjustments to align more with current Lux UI

I've split them up here into separate commits here, but I'd be happy to split them into separate PRs if you'd be interesting in merging any or all.


example separate entity config:
```yaml
grid_flow:
  entities:
    - consumption: sensor.lux_power_from_grid_live
      production: sensor.lux_power_to_grid_live
```