### PR TITLE
Allow click on grid voltage text to open grid voltage chart

### DIFF
--- a/lux-power-distribution-card.js
+++ b/lux-power-distribution-card.js
@@ -135,6 +135,7 @@ class LuxPowerDistributionCard extends HTMLElement {
       "#battery-image": "battery_flow",
       "#battery-soc-info": "battery_soc",
       "#grid-image": "grid_flow",
+      "#grid-info": "grid_info",
     };
     if (!config.backup_power.is_used) {
       history_map["#home-image"] = "home_consumption";


### PR DESCRIPTION
Clicking on the grid voltage text now opens grid voltage chart.

In the current behaviour, Clicking on the grid icon already opens the chart for grid flow but clicking on the grid voltage info text does nothing. Which seems like a missed opportunity.